### PR TITLE
Revert "Fix added energy and range, add back charging power"

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -119,16 +119,18 @@ ENTITIES_CONFIG = {
             "device_class": "plug",
         },
     },
-    "charging_power": {
-        "component": "sensor",
-        "config": {
-            "name": "Charging power",
-            "device_class": "power",
-            "unit_of_measurement": "W",
-            "state_class": "total",
-            "suggested_display_precision": 1,
-        },
-    },
+    # TODO: Uncomment after fixing.
+    # Commented out because it doesn't reset to 0 in db after done charging or paused.
+    # "charging_power": {
+    #     "component": "sensor",
+    #     "config": {
+    #         "name": "Charging power",
+    #         "device_class": "power",
+    #         "unit_of_measurement": "W",
+    #         "state_class": "total",
+    #         "suggested_display_precision": 1,
+    #     },
+    # },
     "status": {
         "component": "sensor",
         "getter": lambda: wallbox_status_codes[int(redis_connection.hget("m2w", "tms.charger_status"))],
@@ -171,25 +173,15 @@ ENTITIES_CONFIG = {
 
 DB_QUERY = """
 SELECT
-  `wallbox_config`.`charging_enable`,
-  `wallbox_config`.`lock`,
-  `wallbox_config`.`max_charging_current`,
-  `active_session`.`was_connected` AS cable_connected,
-  `latest_state_value`.`ac_current_rms_l1` / 10.0 * `latest_state_value`.`ac_voltage_rms_l1`
-    + `latest_state_value`.`ac_current_rms_l2` / 10.0 * `latest_state_value`.`ac_voltage_rms_l2`
-    + `latest_state_value`.`ac_current_rms_l2` / 10.0 * `latest_state_value`.`ac_voltage_rms_l3` AS charging_power,
-  `power_outage_values`.`charged_energy` AS cumulative_added_energy,
-  IF(`active_session`.`id` != 1,
-    `power_outage_values`.`charged_energy` - `active_session`.`start_charging_energy_tms`,
-    `latest_session`.`energy_total`) AS added_energy,
-  IF(`active_session`.`id` != 1,
-    `active_session`.`charged_range`,
-    `latest_session`.`charged_range`) AS added_range
-FROM `wallbox_config`,
-  `active_session`,
-  `power_outage_values`,
-  (SELECT * FROM `session` ORDER BY `id` DESC LIMIT 1) AS latest_session,
-  (SELECT * FROM `state_values` ORDER BY `id` DESC LIMIT 1) AS latest_state_value;
+  `charging_enable`,
+  `lock`,
+  `max_charging_current`,
+  `was_connected` AS cable_connected,
+  `charging_power`,
+  `latest_sess`.`energy_total` AS added_energy,
+  `charged_energy` AS cumulative_added_energy,
+  `latest_sess`.`charged_range` AS added_range
+FROM `wallbox_config`, `active_session`, `power_outage_values`, (SELECT * FROM `session` ORDER BY `id` DESC LIMIT 1) latest_sess;
 """
 
 mqttc = mqtt.Client()


### PR DESCRIPTION
Reverts jagheterfredrik/wallbox-mqtt-bridge#5

Apparently charging_power is considered an <class 'decimal.Decimal'> and publish has issues with that
```
Traceback (most recent call last):
  File "bridge.py", line 273, in <module>
    mqttc.publish(topic_prefix + "/" + key + "/state", val, retain=True)
  File "/home/root/mqtt-bridge/venv/lib/python3.5/site-packages/paho/mqtt/client.py", line 1248, in publish
    'payload must be a string, bytearray, int, float or None.')
TypeError: payload must be a string, bytearray, int, float or None.
```