### PR TITLE
run mqtt in the main thread

### DIFF
--- a/mqtt-bridge/bridge.py
+++ b/mqtt-bridge/bridge.py
@@ -291,8 +291,7 @@ try:
     mqttc.on_message = _on_message
     mqttc.username_pw_set(mqtt_username, mqtt_password)
     print("Connecting to MQTT", mqtt_host, mqtt_port)
-    mqttc.connect_async(mqtt_host, mqtt_port)
-    mqttc.loop_start()
+    mqttc.connect(mqtt_host, mqtt_port)
 
     published = {}  # type: Dict[str, Any]
     # If we change more than this, we publish even though we're rate limited
@@ -320,9 +319,9 @@ try:
                     published[key] = val
             if publish_rate_limited:
                 latest_rate_limit_publish = time.time()
-        time.sleep(polling_interval_seconds)
+        mqttc.loop(timeout=polling_interval_seconds)
 
 finally:
+    mqttc.disconnect()
     connection.close()
     redis_connection.close()
-    mqttc.loop_stop()


### PR DESCRIPTION
Seen this error from time to time:

```
Traceback (most recent call last):
  File "bridge.py", line 307, in <module>
    result = sql_execute(DB_QUERY)
  File "bridge.py", line 60, in sql_execute
    cursor.execute(sql, args)
  File "/home/root/mqtt-bridge/venv/lib/python3.5/site-packages/pymysql/cursors.py", line 163, in execute
    result = self._query(query)
  File "/home/root/mqtt-bridge/venv/lib/python3.5/site-packages/pymysql/cursors.py", line 321, in _query
    conn.query(q)
  File "/home/root/mqtt-bridge/venv/lib/python3.5/site-packages/pymysql/connections.py", line 505, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/root/mqtt-bridge/venv/lib/python3.5/site-packages/pymysql/connections.py", line 724, in _read_query_result
    result.read()
  File "/home/root/mqtt-bridge/venv/lib/python3.5/site-packages/pymysql/connections.py", line 1069, in read
    first_packet = self.connection._read_packet()
  File "/home/root/mqtt-bridge/venv/lib/python3.5/site-packages/pymysql/connections.py", line 660, in _read_packet
    % (packet_number, self._next_seq_id))
pymysql.err.InternalError: Packet sequence number wrong - got 1 expected 6
```

I assume it is because MQTT `_on_message` will run in a separate thread and compete for the SQL connection? Any objections to running MQTT on the main thread?