### PR TITLE
Set entity_category: config for Halo Brightness

### DIFF
--- a/mqtt-bridge/bridge.py
+++ b/mqtt-bridge/bridge.py
@@ -178,6 +178,7 @@ ENTITIES_CONFIG = {
             "max": 100,
             "icon": "mdi:brightness-percent",
             "unit_of_measurement": "%",
+            "entity_category": "config",
         },
     },
     "cable_connected": {


### PR DESCRIPTION
Per https://developers.home-assistant.io/docs/core/entity/#registry-properties entity_category: config is more appropriate for Halo Brightness