### PR TITLE
use correct state_class for charging_power

### DIFF
--- a/app/sensors.go
+++ b/app/sensors.go
@@ -80,7 +80,7 @@ func getEntities(w *wallbox.Wallbox) map[string]Entity {
 				"name":                        "Charging power",
 				"device_class":                "power",
 				"unit_of_measurement":         "W",
-				"state_class":                 "total",
+				"state_class":                 "measurement",
 				"suggested_display_precision": "1",
 			},
 		},


### PR DESCRIPTION
State class total is not correct for power entities - changed to measurement. This solves error message in HA log:

```
Entity sensor.wallbox_charging_power (<class 'homeassistant.components.mqtt.sensor.MqttSensor'>) is using state class 'total' which is impossible considering device class ('power') it is using; expected None or one of 'measurement'; 
Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+mqtt%22
```