### PR TITLE
Add power boost sensors

### DIFF
--- a/app/bridge.go
+++ b/app/bridge.go
@@ -31,6 +31,12 @@ func LaunchBridge(configPath string) {
 		}
 	}
 
+	if c.Settings.PowerBoostEnabled {
+		for k, v := range getPowerBoostEntities(w, c) {
+			entityConfig[k] = v
+		}
+	}
+
 	topicPrefix := "wallbox_" + serialNumber
 	availabilityTopic := topicPrefix + "/availability"
 

--- a/app/bridge.go
+++ b/app/bridge.go
@@ -89,14 +89,20 @@ func LaunchBridge(configPath string) {
 
 	published := make(map[string]interface{})
 	rateLimiter := map[string]*ratelimit.DeltaRateLimit{
-		"charging_power":      ratelimit.NewDeltaRateLimit(10, 100),
-		"charging_power_l1":   ratelimit.NewDeltaRateLimit(10, 100),
-		"charging_power_l2":   ratelimit.NewDeltaRateLimit(10, 100),
-		"charging_power_l3":   ratelimit.NewDeltaRateLimit(10, 100),
-		"charging_current_l1": ratelimit.NewDeltaRateLimit(10, 0.2),
-		"charging_current_l2": ratelimit.NewDeltaRateLimit(10, 0.2),
-		"charging_current_l3": ratelimit.NewDeltaRateLimit(10, 0.2),
-		"added_energy":        ratelimit.NewDeltaRateLimit(10, 50),
+		"charging_power":         ratelimit.NewDeltaRateLimit(10, 100),
+		"charging_power_l1":      ratelimit.NewDeltaRateLimit(10, 100),
+		"charging_power_l2":      ratelimit.NewDeltaRateLimit(10, 100),
+		"charging_power_l3":      ratelimit.NewDeltaRateLimit(10, 100),
+		"charging_current_l1":    ratelimit.NewDeltaRateLimit(10, 0.2),
+		"charging_current_l2":    ratelimit.NewDeltaRateLimit(10, 0.2),
+		"charging_current_l3":    ratelimit.NewDeltaRateLimit(10, 0.2),
+		"power_boost_power_l1":   ratelimit.NewDeltaRateLimit(10, 100),
+		"power_boost_power_l2":   ratelimit.NewDeltaRateLimit(10, 100),
+		"power_boost_power_l3":   ratelimit.NewDeltaRateLimit(10, 100),
+		"power_boost_current_l1": ratelimit.NewDeltaRateLimit(10, 0.2),
+		"power_boost_current_l2": ratelimit.NewDeltaRateLimit(10, 0.2),
+		"power_boost_current_l3": ratelimit.NewDeltaRateLimit(10, 0.2),
+		"added_energy":           ratelimit.NewDeltaRateLimit(10, 50),
 	}
 
 	for {

--- a/app/config.go
+++ b/app/config.go
@@ -16,6 +16,7 @@ type WallboxConfig struct {
 		PollingIntervalSeconds int    `ini:"polling_interval_seconds"`
 		DeviceName             string `ini:"device_name"`
 		DebugSensors           bool   `ini:"debug_sensors"`
+		PowerBoostEnabled      bool   `ini:"power_boost_enabled"`
 	} `ini:"settings"`
 }
 

--- a/app/sensors.go
+++ b/app/sensors.go
@@ -162,6 +162,95 @@ func getEntities(w *wallbox.Wallbox) map[string]Entity {
 				"suggested_display_precision": "1",
 			},
 		},
+		"power_boost_power_l1": {
+			Component: "sensor",
+			Getter: func() string {
+				return fmt.Sprint(w.Data.RedisM2W.PowerBoostLine1Power)
+			},
+			Config: map[string]string{
+				"name":                        "Power Boost L1",
+				"device_class":                "power",
+				"unit_of_measurement":         "W",
+				"state_class":                 "measurement",
+				"suggested_display_precision": "1",
+			},
+		},
+		"power_boost_power_l2": {
+			Component: "sensor",
+			Getter: func() string {
+				return fmt.Sprint(w.Data.RedisM2W.PowerBoostLine2Power)
+			},
+			Config: map[string]string{
+				"name":                        "Power Boost L2",
+				"device_class":                "power",
+				"unit_of_measurement":         "W",
+				"state_class":                 "measurement",
+				"suggested_display_precision": "1",
+			},
+		},
+		"power_boost_power_l3": {
+			Component: "sensor",
+			Getter: func() string {
+				return fmt.Sprint(w.Data.RedisM2W.PowerBoostLine3Power)
+			},
+			Config: map[string]string{
+				"name":                        "Power Boost L3",
+				"device_class":                "power",
+				"unit_of_measurement":         "W",
+				"state_class":                 "measurement",
+				"suggested_display_precision": "1",
+			},
+		},
+		"power_boost_current_l1": {
+			Component: "sensor",
+			Getter: func() string {
+				return fmt.Sprint(w.Data.RedisM2W.PowerBoostLine1Current)
+			},
+			Config: map[string]string{
+				"name":                        "Power Boost current L1",
+				"device_class":                "current",
+				"unit_of_measurement":         "A",
+				"state_class":                 "measurement",
+				"suggested_display_precision": "1",
+			},
+		},
+		"power_boost_current_l2": {
+			Component: "sensor",
+			Getter: func() string {
+				return fmt.Sprint(w.Data.RedisM2W.PowerBoostLine2Current)
+			},
+			Config: map[string]string{
+				"name":                        "Power Boost current L2",
+				"device_class":                "current",
+				"unit_of_measurement":         "A",
+				"state_class":                 "measurement",
+				"suggested_display_precision": "1",
+			},
+		},
+		"power_boost_current_l3": {
+			Component: "sensor",
+			Getter: func() string {
+				return fmt.Sprint(w.Data.RedisM2W.PowerBoostLine3Current)
+			},
+			Config: map[string]string{
+				"name":                        "Power Boost current L3",
+				"device_class":                "current",
+				"unit_of_measurement":         "A",
+				"state_class":                 "measurement",
+				"suggested_display_precision": "1",
+			},
+		},
+		"power_boost_cumulative_added_energy": {
+			Component: "sensor",
+			Getter:    func() string { return fmt.Sprint(w.Data.RedisM2W.PowerBoostCumulativeEnergy) },
+			Config: map[string]string{
+				"name":                        "Power Boost Cumulative added energy",
+				"device_class":                "energy",
+				"unit_of_measurement":         "Wh",
+				"state_class":                 "total_increasing",
+				"suggested_display_precision": "1",
+			},
+		},
 		"cumulative_added_energy": {
 			Component: "sensor",
 			Getter:    func() string { return fmt.Sprint(w.Data.SQL.CumulativeAddedEnergy) },

--- a/app/sensors.go
+++ b/app/sensors.go
@@ -162,6 +162,69 @@ func getEntities(w *wallbox.Wallbox) map[string]Entity {
 				"suggested_display_precision": "1",
 			},
 		},
+		"cumulative_added_energy": {
+			Component: "sensor",
+			Getter:    func() string { return fmt.Sprint(w.Data.SQL.CumulativeAddedEnergy) },
+			Config: map[string]string{
+				"name":                        "Cumulative added energy",
+				"device_class":                "energy",
+				"unit_of_measurement":         "Wh",
+				"state_class":                 "total_increasing",
+				"suggested_display_precision": "1",
+			},
+		},
+		"halo_brightness": {
+			Component: "number",
+			Setter:    func(val string) { w.SetHaloBrightness(strToInt(val)) },
+			Getter:    func() string { return strconv.Itoa(w.Data.SQL.HaloBrightness) },
+			Config: map[string]string{
+				"name":                "Halo Brightness",
+				"command_topic":       "~/set",
+				"min":                 "0",
+				"max":                 "100",
+				"icon":                "mdi:brightness-percent",
+				"unit_of_measurement": "%",
+				"entity_category":     "config",
+			},
+		},
+		"lock": {
+			Component: "lock",
+			Setter:    func(val string) { w.SetLocked(strToInt(val)) },
+			Getter:    func() string { return strconv.Itoa(w.Data.SQL.Lock) },
+			Config: map[string]string{
+				"name":           "Lock",
+				"payload_lock":   "1",
+				"payload_unlock": "0",
+				"state_locked":   "1",
+				"state_unlocked": "0",
+				"command_topic":  "~/set",
+			},
+		},
+		"max_charging_current": {
+			Component: "number",
+			Setter:    func(val string) { w.SetMaxChargingCurrent(strToInt(val)) },
+			Getter:    func() string { return strconv.Itoa(w.Data.SQL.MaxChargingCurrent) },
+			Config: map[string]string{
+				"name":                "Max charging current",
+				"command_topic":       "~/set",
+				"min":                 "6",
+				"max":                 strconv.Itoa(w.AvailableCurrent()),
+				"unit_of_measurement": "A",
+				"device_class":        "current",
+			},
+		},
+		"status": {
+			Component: "sensor",
+			Getter:    w.EffectiveStatus,
+			Config: map[string]string{
+				"name": "Status",
+			},
+		},
+	}
+}
+
+func getPowerBoostEntities(w *wallbox.Wallbox, c *WallboxConfig) map[string]Entity {
+	return map[string]Entity{
 		"power_boost_power_l1": {
 			Component: "sensor",
 			Getter: func() string {
@@ -249,64 +312,6 @@ func getEntities(w *wallbox.Wallbox) map[string]Entity {
 				"unit_of_measurement":         "Wh",
 				"state_class":                 "total_increasing",
 				"suggested_display_precision": "1",
-			},
-		},
-		"cumulative_added_energy": {
-			Component: "sensor",
-			Getter:    func() string { return fmt.Sprint(w.Data.SQL.CumulativeAddedEnergy) },
-			Config: map[string]string{
-				"name":                        "Cumulative added energy",
-				"device_class":                "energy",
-				"unit_of_measurement":         "Wh",
-				"state_class":                 "total_increasing",
-				"suggested_display_precision": "1",
-			},
-		},
-		"halo_brightness": {
-			Component: "number",
-			Setter:    func(val string) { w.SetHaloBrightness(strToInt(val)) },
-			Getter:    func() string { return strconv.Itoa(w.Data.SQL.HaloBrightness) },
-			Config: map[string]string{
-				"name":                "Halo Brightness",
-				"command_topic":       "~/set",
-				"min":                 "0",
-				"max":                 "100",
-				"icon":                "mdi:brightness-percent",
-				"unit_of_measurement": "%",
-				"entity_category":     "config",
-			},
-		},
-		"lock": {
-			Component: "lock",
-			Setter:    func(val string) { w.SetLocked(strToInt(val)) },
-			Getter:    func() string { return strconv.Itoa(w.Data.SQL.Lock) },
-			Config: map[string]string{
-				"name":           "Lock",
-				"payload_lock":   "1",
-				"payload_unlock": "0",
-				"state_locked":   "1",
-				"state_unlocked": "0",
-				"command_topic":  "~/set",
-			},
-		},
-		"max_charging_current": {
-			Component: "number",
-			Setter:    func(val string) { w.SetMaxChargingCurrent(strToInt(val)) },
-			Getter:    func() string { return strconv.Itoa(w.Data.SQL.MaxChargingCurrent) },
-			Config: map[string]string{
-				"name":                "Max charging current",
-				"command_topic":       "~/set",
-				"min":                 "6",
-				"max":                 strconv.Itoa(w.AvailableCurrent()),
-				"unit_of_measurement": "A",
-				"device_class":        "current",
-			},
-		},
-		"status": {
-			Component: "sensor",
-			Getter:    w.EffectiveStatus,
-			Config: map[string]string{
-				"name": "Status",
 			},
 		},
 	}

--- a/app/tui.go
+++ b/app/tui.go
@@ -47,6 +47,7 @@ func RunTuiSetup() {
 	config.Settings.PollingIntervalSeconds = 1
 	config.Settings.DeviceName = "Wallbox"
 	config.Settings.DebugSensors = false
+	config.Settings.PowerBoostEnabled = false
 
 	askConfirmOrNew(&config.MQTT.Host, "MQTT Host")
 	askConfirmOrNewInt(&config.MQTT.Port, "MQTT Port")
@@ -55,6 +56,7 @@ func RunTuiSetup() {
 	askConfirmOrNewInt(&config.Settings.PollingIntervalSeconds, "Polling interval")
 	askConfirmOrNew(&config.Settings.DeviceName, "Device name")
 	askConfirmOrNewBool(&config.Settings.DebugSensors, "Debug sensors")
+	askConfirmOrNewBool(&config.Settings.PowerBoostEnabled, "Enable Power Boost sensors")
 
 	config.SaveTo("bridge.ini")
 }

--- a/app/wallbox/wallbox.go
+++ b/app/wallbox/wallbox.go
@@ -29,13 +29,20 @@ type DataCache struct {
 	}
 
 	RedisM2W struct {
-		ChargerStatus int     `redis:"tms.charger_status"`
-		Line1Power    float64 `redis:"tms.line1.power_watt.value"`
-		Line2Power    float64 `redis:"tms.line2.power_watt.value"`
-		Line3Power    float64 `redis:"tms.line3.power_watt.value"`
-		Line1Current  float64 `redis:"tms.line1.current_amp.value"`
-		Line2Current  float64 `redis:"tms.line2.current_amp.value"`
-		Line3Current  float64 `redis:"tms.line3.current_amp.value"`
+		ChargerStatus              int     `redis:"tms.charger_status"`
+		Line1Power                 float64 `redis:"tms.line1.power_watt.value"`
+		Line2Power                 float64 `redis:"tms.line2.power_watt.value"`
+		Line3Power                 float64 `redis:"tms.line3.power_watt.value"`
+		Line1Current               float64 `redis:"tms.line1.current_amp.value"`
+		Line2Current               float64 `redis:"tms.line2.current_amp.value"`
+		Line3Current               float64 `redis:"tms.line3.current_amp.value"`
+		PowerBoostLine1Power       float64 `redis:"PBO.line1.power.value"`
+		PowerBoostLine2Power       float64 `redis:"PBO.line2.power.value"`
+		PowerBoostLine3Power       float64 `redis:"PBO.line3.power.value"`
+		PowerBoostLine1Current     float64 `redis:"PBO.line1.current.value"`
+		PowerBoostLine2Current     float64 `redis:"PBO.line2.current.value"`
+		PowerBoostLine3Current     float64 `redis:"PBO.line3.current.value"`
+		PowerBoostCumulativeEnergy float64 `redis:"PBO.energy_wh.value"`
 	}
 }
 


### PR DESCRIPTION
This commit adds support for the [Wallbox Power Boost feature](https://support.wallbox.com/na/knowledge-base/energy-management-solutions/#powerboost). This is basically a separate device (seems like its a rebranded Inepro PRO380?), which is connected to the charger over modbus. The stock firmware conveniently puts a bunch of statistics about the device in Redis, which this PR exposes as sensors for Home Assistant. It basically makes it possible to monitor the energy usage of a whole household through this feature.

I hope you like it, I threw this together in less than an hour and I actually cannot test it without a power boost device.