### PR TITLE
Added possiblity to configure interval updated topics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ bridge-arm64
 
 # Go workspace file
 go.work
+
+bridge.ini
+launch.json

--- a/app/config.go
+++ b/app/config.go
@@ -13,10 +13,13 @@ type WallboxConfig struct {
 	} `ini:"mqtt"`
 
 	Settings struct {
-		PollingIntervalSeconds int    `ini:"polling_interval_seconds"`
-		DeviceName             string `ini:"device_name"`
-		DebugSensors           bool   `ini:"debug_sensors"`
-		PowerBoostEnabled      bool   `ini:"power_boost_enabled"`
+		PollingIntervalSeconds       int      `ini:"polling_interval_seconds"`
+		DeviceName                   string   `ini:"device_name"`
+		DebugSensors                 bool     `ini:"debug_sensors"`
+		PowerBoostEnabled            bool     `ini:"power_boost_enabled"`
+		IntervalUpdatedTopics        []string `ini:"interval_updated_topics"`
+		IntervalUpdatedTopicsSeconds int      `ini:"interval_updated_topics_seconds"`
+		VerboseOutput                bool     `ini:"verbose_output"`
 	} `ini:"settings"`
 }
 

--- a/app/tui.go
+++ b/app/tui.go
@@ -48,6 +48,9 @@ func RunTuiSetup() {
 	config.Settings.DeviceName = "Wallbox"
 	config.Settings.DebugSensors = false
 	config.Settings.PowerBoostEnabled = false
+	config.Settings.VerboseOutput = false
+	config.Settings.IntervalUpdatedTopics = []string{"charging_enable"}
+	config.Settings.IntervalUpdatedTopicsSeconds = 5
 
 	askConfirmOrNew(&config.MQTT.Host, "MQTT Host")
 	askConfirmOrNewInt(&config.MQTT.Port, "MQTT Port")
@@ -57,6 +60,7 @@ func RunTuiSetup() {
 	askConfirmOrNew(&config.Settings.DeviceName, "Device name")
 	askConfirmOrNewBool(&config.Settings.DebugSensors, "Debug sensors")
 	askConfirmOrNewBool(&config.Settings.PowerBoostEnabled, "Enable Power Boost sensors")
-
+	askConfirmOrNewBool(&config.Settings.VerboseOutput, "Enable verbose output (very noisy)")
+	askConfirmOrNewInt(&config.Settings.IntervalUpdatedTopicsSeconds, "Update interval seconds for interval updated topics")
 	config.SaveTo("bridge.ini")
 }


### PR DESCRIPTION
In conjuction with evcc (https://evcc.io) an constant update of certain topics is needed to ensure the state doesn't get stale.

This change adds a mechanism to configure the update topics aswell as a update interval.