### PR TITLE
Change SetChargingEnable to mimic SetLocked for CPB1

### DIFF
--- a/app/wallbox/wallbox.go
+++ b/app/wallbox/wallbox.go
@@ -376,7 +376,11 @@ func (w *Wallbox) SetChargingEnable(enable int) {
 	if enable == w.ChargingEnable() {
 		return
 	}
-	if enable == 1 {
+	if w.ChargerType == "CPB1" {
+		if _, err := w.sqlClient.Exec("UPDATE `wallbox_config` SET `charging_enable`=?", enable); err != nil {
+			fmt.Println("SQL error in SetChargingEnable:", err)
+		}
+	} else if enable == 1 {
 		sendToPosixQueue("WALLBOX_MYWALLBOX_WALLBOX_STATEMACHINE", "EVENT_REQUEST_USER_ACTION#1.000000")
 	} else {
 		sendToPosixQueue("WALLBOX_MYWALLBOX_WALLBOX_STATEMACHINE", "EVENT_REQUEST_USER_ACTION#2.000000")


### PR DESCRIPTION
For CPB1 devices update charging_enable via SQL directly instead of sending EVENT_REQUEST_USER_ACTION via POSIX similar to SetLocked.

Potentially fix #101