### PR TITLE
fix(sensors): rate-limit cumulative_added_energy publishes

### DIFF
--- a/app/sensors.go
+++ b/app/sensors.go
@@ -161,6 +161,7 @@ func getEntities(w *wallbox.Wallbox) map[string]Entity {
 		"cumulative_added_energy": {
 			Component: "sensor",
 			Getter:    func() string { return fmt.Sprint(w.CumulativeAddedEnergy()) },
+			RateLimit: ratelimit.NewDeltaRateLimit(10, 100),
 			Config: map[string]string{
 				"name":                        "Cumulative added energy",
 				"device_class":                "energy",


### PR DESCRIPTION
## Summary

Add a `RateLimit` to `cumulative_added_energy`, matching the existing pattern
for other measurement-frequency sensors (`charging_power`, `voltage_l1`, etc.):

```diff
 "cumulative_added_energy": {
     Component: "sensor",
     Getter:    func() string { return fmt.Sprint(w.CumulativeAddedEnergy()) },
+    RateLimit: ratelimit.NewDeltaRateLimit(10, 100),
     ...
 },
```

## Why

`cumulative_added_energy` updates at the wallbox's telemetry cadence —
empirically ~1.5 events/sec during a high-current charging session (verified
by @tronikos via `redis-cli SUBSCRIBE` and HA's recorder DB: ~2201 events
over a 30-min charge, ~73/min). With no rate limit, that's ~4400 HA recorder
events per hour on a single topic during charging, which dominates the
recorder write load and produces the same volume of bridge journal lines.

A `NewDeltaRateLimit(10, 100)` brings it in line with other measurement
sensors. At 7.6 kW the time check fires first (≥10 s elapsed → publish), so
the publish rate drops to ~6/min. The cumulative total in HA is unaffected —
`total_increasing` reads the absolute counter at each publish, and rate
limiting only reduces the temporal resolution of intermediate updates,
not the final integral.

## What this PR is NOT

In a previous revision I framed this as preventing a publish flood that
triggered an MQTT disconnect we observed in production. That framing was
wrong — see @tronikos's review for the full set of corrections. The publish
rate is nowhere near broker/paho saturation thresholds. The disconnect
appears to have been network-side (mosquitto's other clients on the same
broker were unaffected at the same instant), with WiFi/RF the most likely
specific suspect since the wallbox is the only wireless device on that
path — though we don't have direct WiFi-link logs to confirm.
`cumulative_added_energy` was just the loudest topic in the journal because
it's the most frequent, not because it caused anything. #108 (deterministic
ClientID) is the actual fix for the LWT race the disconnect exposed.

So treat this as a small QoL noise reduction. Optional, harmless, in line
with how other measurement-frequency sensors are already handled.

## Test plan

- [x] Built with `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build`
- [x] Deployed to live Pulsar Plus (firmware 6.8.12)
- [x] `cumulative_added_energy` continues to publish during charging at the
      rate-limited cadence; HA Energy dashboard total unchanged
- [x] No regression in other sensors
