### PR TITLE
fix(bridge): periodically republish availability=online to defeat LWT race on reconnect

### DIFF
--- a/app/bridge.go
+++ b/app/bridge.go
@@ -19,6 +19,16 @@ const (
 	mqttPublishTimeout    = 2 * time.Second
 	mqttReconnectInterval = 10 * time.Second
 	mqttInitialRetryDelay = 5 * time.Second
+
+	// Republish availability=online retained on this cadence to defeat
+	// the LWT race that follows any reconnect. After a reconnect, onConnect
+	// publishes online retained — but the broker may still be processing
+	// the stale-session timeout for the OLD session, and its LWT publish
+	// fires AFTER session timeout, NOT at TCP disconnect. The LWT can land
+	// 1+ seconds AFTER our online publish and overwrite it. A periodic
+	// republish guarantees the topic returns to online within this
+	// interval regardless of LWT timing.
+	availabilityRepublishInterval = 30 * time.Second
 )
 
 func RunBridge(configPath string) {
@@ -178,6 +188,9 @@ func RunBridge(configPath string) {
 	ticker := time.NewTicker(time.Duration(c.Settings.PollingIntervalSeconds) * time.Second)
 	defer ticker.Stop()
 
+	availabilityTicker := time.NewTicker(availabilityRepublishInterval)
+	defer availabilityTicker.Stop()
+
 	// publishChanged iterates every entity, evaluates its getter, and publishes
 	// to MQTT if the value has changed since the last publish — subject to the
 	// entity's rate limiter. It is called both on ticker ticks (after a full
@@ -224,6 +237,14 @@ func RunBridge(configPath string) {
 			// Full refresh
 			w.RefreshData()
 			publishChanged()
+
+		case <-availabilityTicker.C:
+			// Periodic LWT-race recovery (see availabilityRepublishInterval).
+			// No-op when disconnected; paho's auto-reconnect will fire onConnect
+			// and republish availability when the broker comes back.
+			if client.IsConnected() {
+				client.Publish(availabilityTopic, 1, true, "online")
+			}
 
 		case <-w.Updates:
 			// Instant Real-Time loop: pub/sub event arrived


### PR DESCRIPTION
## Summary

When the bridge reconnects to MQTT (after any disconnect — keepalive timeout, broker restart, network blip), the `OnConnect` handler publishes `<topic>/availability=online` retained at `app/bridge.go:132`. But the broker delivers the **OLD** session's LWT message AFTER its stale-session timeout fires, NOT at the TCP disconnect moment. The LWT publish can land 1+ seconds AFTER OnConnect's `online` and overwrite the retained topic with `offline`.

This PR adds a 30 s ticker that republishes `availability=online` retained as long as the client is connected, so any reconnect race is automatically corrected within ≤30 s.

## Why this is a real race, not a theoretical one

Reproduced in production. Mosquitto 2.1.2 broker log shows:

```
12:46:54  New connection from 192.168.1.11:35008 ... auto-CB4DAA80 (p4, c1, k30, u'wallbox-bridge')
12:46:55  Client auto-CE47DBBB-... [60512] disconnected: exceeded timeout.
```

Bridge log at the same instant:

```
12:46:54  MQTT connection lost: pingresp not received, disconnecting — reconnecting automatically
12:46:54  Connected to MQTT broker. Publishing discovery configs...
```

Sequence:

1. T+0s: bridge declares its TCP dead, opens new connection, publishes `availability=online` retained.
2. T+1s: broker finally times out the OLD session's keepalive, fires its LWT `availability=offline` retained → **overwrites step 1**.
3. Final state: `availability=offline` retained. Every HA entity tied to that availability_topic stays at `unavailable` indefinitely.
4. The bridge process keeps publishing telemetry to other topics, but no HA subscriber sees it.

This wasn't recoverable without either restarting the bridge service or manually publishing `online` retained from the broker host.

## What changes

```go
const (
    ...
+   availabilityRepublishInterval = 30 * time.Second
)
```

```go
+   availabilityTicker := time.NewTicker(availabilityRepublishInterval)
+   defer availabilityTicker.Stop()
```

```go
    for {
        select {
        case <-ticker.C:
            ...

+       case <-availabilityTicker.C:
+           if client.IsConnected() {
+               client.Publish(availabilityTopic, 1, true, "online")
+           }
+
        case <-w.Updates:
        ...
```

## Why 30 s

- Well below typical downstream watchdog thresholds (60–120 s).
- Negligible broker load: one publish per 30 s vs. many publishes per second of telemetry already on the wire.
- Survives multiple consecutive race losses without manual recovery.

## Test plan

- [x] Built with `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build`
- [x] Deployed to live Pulsar Plus (firmware 6.8.12) — bridge restarts cleanly
- [x] Subscribed `wallbox_<serial>/availability` and observed periodic republish at the 30 s cadence:

  ```
  + 0.0s  retain=True   wallbox_1326777/availability = online   (initial retained read)
  + 9.3s  retain=False  wallbox_1326777/availability = online   (bridge ticker)
  +39.4s  retain=False  wallbox_1326777/availability = online   (bridge ticker)
  +69.4s  retain=False  wallbox_1326777/availability = online   (bridge ticker)
  ```

- [x] No-op when disconnected (`client.IsConnected()` guard); paho's auto-reconnect still drives `OnConnect` on reconnection, which already republishes availability.
- [x] No regression in other timing (`ticker` and `w.Updates` cases unchanged).

## Companion patch

This PR closes the race generically. The other companion PR (rate-limit `cumulative_added_energy`) removes one specific trigger that exposed this race in production. They are independent and can be merged in either order.