### PR TITLE
fix(bridge): use deterministic MQTT ClientID to prevent LWT race on reconnect

### DIFF
--- a/app/bridge.go
+++ b/app/bridge.go
@@ -152,6 +152,9 @@ func RunBridge(configPath string) {
 	opts.SetPassword(c.MQTT.Password)
 	opts.SetWill(availabilityTopic, "offline", 1, true)
 
+	// use deterministic ClientID to prevent LWT race on reconnect
+	opts.SetClientID("wallbox-mqtt-bridge-" + serialNumber)
+
 	// Enable paho's built-in reconnect logic so a transient broker outage
 	// (HA update, network blip) never crashes the bridge.
 	opts.SetAutoReconnect(true)


### PR DESCRIPTION
## Summary

Set a stable MQTT `ClientID` derived from the charger serial so that any reconnect on the same charger triggers an MQTT **session takeover**, rather than being treated as a separate, coexisting connection.

```diff
+    // use deterministic ClientID to prevent LWT race on reconnect
+    opts.SetClientID("wallbox-mqtt-bridge-" + serialNumber)
```

One line of effective change.

## Why

This supersedes #107, which proposed a 30 s periodic-republish ticker as a recovery mechanism. [@tronikos suggested](https://github.com/jagheterfredrik/wallbox-mqtt-bridge/pull/107#issuecomment-4413341871) that a deterministic ClientID would *prevent* the race rather than recover from it. Empirical testing confirms it does — and is much cleaner.

### The race we're fixing

Reproduced in production with auto-generated ClientIDs on Mosquitto 2.1.2:

```
12:46:54  New connection from 192.168.1.11:35008 ... auto-CB4DAA80
12:46:55  Client auto-CE47DBBB-... [60512] disconnected: exceeded timeout.
```

Different ClientIDs (paho generates a fresh random one on every reconnect) → broker accepts new connection as a separate session → ~45 s (1.5 × keepalive) later the broker finally times out the OLD session and fires its LWT (`<topic>/availability=offline` retained) → overwrites the `online` retained that the new session's `onConnect` already published. Result: every HA entity gated on availability_topic stays `unavailable` until manual recovery.

### Why a stable ClientID fixes it (verified)

With the same ClientID across reconnects, paho's reconnect triggers an MQTT session takeover. The broker disconnects the OLD session synchronously during the new CONNECT processing. The LWT *does* fire on takeover (verified empirically on Mosquitto 2.1.2 — see below), but the broker stores its retained payload BEFORE sending CONNACK. By the time `onConnect` runs and publishes `online` retained, the LWT's `offline` is already in the retained store and gets overwritten in the correct order.

Test with ClientID="static" on Mosquitto 2.1.2:

```
+ 2.00s  B: connecting (takeover)
+ 2.03s  watcher: payload='OFFLINE-from-LWT'        ← LWT fires on takeover
+ 2.03s  B: OnConnect — publishing ONLINE retained
+ 2.08s  watcher: payload='B-ONLINE'
+ 5.09s  CHECK retained=true payload='B-ONLINE'     ← final state correct
```

Final retained value is `B-ONLINE` because the broker sequenced the publishes correctly: takeover Will → CONNACK → `onConnect` overwrites with online.

## Test plan

- [x] Built with `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build`
- [x] Deployed to live Pulsar Plus (firmware 6.8.12) — bridge restarts cleanly with stable ClientID `wallbox-mqtt-bridge-<serial>`
- [x] Mosquitto broker log confirms a single stable session per ClientID across reconnects (no more `auto-XXXX` proliferation)
- [x] No regression in other timing or behavior

## Note

The LWT firing on takeover is undefined by MQTT 3.1.1 spec but appears to be the de-facto behaviour for at least Mosquitto 2.x. The fix works regardless because the broker sequences takeover events correctly. If a hypothetical broker DID send CONNACK before processing the Will, this fix would still work the same way as auto-generated ClientIDs do today (i.e., it would be no worse than the current state).

Closes #107.
